### PR TITLE
Expose per address memcached stats (massaged / backported upstream PR https://github.com/bradfitz/gomemcache/pull/24)

### DIFF
--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -164,6 +164,14 @@ func testIncrDecrWithClient(t *testing.T, c MemcacheClient) {
 	}
 }
 
+func testStatsWithClient(t *testing.T, c MemcacheClient) {
+	stats, err := c.Stats()
+	checkErr(t, c, err, "Stats: %v", err)
+	if n := len(stats); err != nil || n == 0 {
+		t.Errorf("Stats: didn't get stats")
+	}
+}
+
 func testWithClient(t *testing.T, c MemcacheClient) {
 
 	testSetWithClient(t, c)
@@ -178,4 +186,5 @@ func testWithClient(t *testing.T, c MemcacheClient) {
 
 	testIncrDecrWithClient(t, c)
 
+	testStatsWithClient(t, c)
 }


### PR DESCRIPTION
Backported only the stats command from upstream PR https://github.com/bradfitz/gomemcache/pull/24

```
vagrant@vagrant:~/src/gomemcache/memcache$ go test memcache_test.go memcache.go selector.go
ok  	command-line-arguments	0.082s
```

@eapache @jnormore @pallan 