### PR TITLE
Fix stats for multiple memcached instances

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -349,13 +349,13 @@ func (c *Client) Stats() (map[net.Addr]map[string]string, error) {
 	defer ss.lk.RUnlock()
 	for _, addr := range ss.addrs {
 		sn += 1
-		go func() {
+		go func(addr net.Addr) {
 			ch <- c.statsFromAddr(addr, func(stat map[string]string) {
 				mu.Lock()
 				defer mu.Unlock()
 				stats[addr] = stat
 			})
-		}()
+		}(addr)
 	}
 
 	var err error


### PR DESCRIPTION
When gomemcache has more than one memcached instance configured, running
`Stats` aimed to return one stat array per instance. This failed due
to overwriting the local `addr` variable in the anonymous goroutine wrapper
function, effectively only returning the stats for the last instance queried.